### PR TITLE
fix: TextMate grammar error where patterns object is not iterable

### DIFF
--- a/grammar/siddhi-grammar/syntaxes/siddhi.tmLanguage.json
+++ b/grammar/siddhi-grammar/syntaxes/siddhi.tmLanguage.json
@@ -535,9 +535,11 @@
         }
       },
       "name": "basic.math.operation.siddhi",
-      "patterns": {
-        "include": "#mathOperation"
-      }
+      "patterns": [
+        {
+          "include": "#mathOperation"
+        }
+      ]
     },
     "definitionFunction": {
       "begin": "(?i)(\\bdefine\\b)(\\s*)(\\bfunction\\b)",

--- a/grammar/siddhi-grammar/syntaxes/siddhi.tmLanguage.yaml
+++ b/grammar/siddhi-grammar/syntaxes/siddhi.tmLanguage.yaml
@@ -271,7 +271,7 @@ repository:
       '0': {name: support.constant.punctuation.paren.close.xdcd.siddhi }
     name: basic.math.operation.siddhi
     patterns:
-      include: '#mathOperation'
+      - include: '#mathOperation'
 
   definitionFunction:
     begin: '(?i)(\bdefine\b)(\s*)(\bfunction\b)'


### PR DESCRIPTION
## Purpose
This particular `patterns` property is not an array but an object. As far as I know, this should always be an array. I noticed it when trying to convert it to Sublime syntax. It occurred both in the JSON and the YAML version.

## Goals
Fixing the syntax error in the 

## Approach
Wraps the object inside an array to match the expectations.

## User stories
N/A

## Release note
Fixes a syntax error in the TextMate grammar used for syntax highlighting.

## Documentation
N/A as it simply corrects the syntax error

## Training
N/A

## Certification
N/A as it simply corrects the syntax error

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A