### PR TITLE
fix: prevent project explorer initialization when no project is opened

### DIFF
--- a/workspaces/si/si-extension/package.json
+++ b/workspaces/si/si-extension/package.json
@@ -32,10 +32,10 @@
       "wso2-integrator": [
         {
           "id": "siProjectExplorer",
-          "name": "WSO2 Integrator: SI",
+          "name": "Integrations",
           "icon": "resources/images/icons/si-icon.svg",
           "contextualTitle": "WSO2 Integrator: SI",
-          "when": "resourceLangId == siddhi || SI.project.loading == true || SI.project.error == true || SI.project.empty == false"
+          "when": "resourceLangId == siddhi || SI.project.loading == true || SI.project.error == true || SI.project.hasSiddhiFiles == true"
         }
       ]
     },

--- a/workspaces/si/si-extension/src/project-explorer/activate.ts
+++ b/workspaces/si/si-extension/src/project-explorer/activate.ts
@@ -13,6 +13,7 @@ import { VS_CODE_COMMANDS, PROJECT_EXPLORER_VIEW_ID } from "../constants";
 import { stateService } from "../stateMachine";
 
 let projectExplorerProvider: ProjectExplorerEntryProvider | undefined;
+let projectExplorerInitialized = false;
 
 interface GraphNodeFocusTarget {
     id?: string;
@@ -26,117 +27,140 @@ interface OpenGraphicalFocusedArgs {
 }
 
 export function activateProjectExplorer(context: vscode.ExtensionContext) {
-    projectExplorerProvider = new ProjectExplorerEntryProvider();
-    let refreshTimeout: NodeJS.Timeout | undefined;
-
-    const scheduleRefresh = () => {
-        if (refreshTimeout) {
-            clearTimeout(refreshTimeout);
+    const initializeProjectExplorer = () => {
+        if (projectExplorerInitialized) {
+            return;
         }
-        refreshTimeout = setTimeout(() => {
-            projectExplorerProvider?.refresh();
-        }, 200);
-    };
 
-    void vscode.commands.executeCommand("setContext", "SI.project.empty", true);
-    void vscode.commands.executeCommand("setContext", "SI.project.loading", false);
-    void vscode.commands.executeCommand("setContext", "SI.project.error", false);
+        projectExplorerInitialized = true;
+        projectExplorerProvider = new ProjectExplorerEntryProvider();
+        let refreshTimeout: NodeJS.Timeout | undefined;
 
-    const treeView = vscode.window.createTreeView(PROJECT_EXPLORER_VIEW_ID, {
-        treeDataProvider: projectExplorerProvider,
-        showCollapseAll: true,
-    });
-    projectExplorerProvider.setTreeView(treeView);
-
-    // Register commands
-    context.subscriptions.push(
-        vscode.commands.registerCommand(VS_CODE_COMMANDS.PROJECT_EXPLORER_REFRESH, () => {
-            projectExplorerProvider?.refresh();
-        }),
-
-        vscode.commands.registerCommand(
-            VS_CODE_COMMANDS.PROJECT_EXPLORER_OPEN_FILE,
-            (fileUri: vscode.Uri) => {
-                vscode.window.showTextDocument(fileUri, { preview: false });
-            },
-        ),
-
-        vscode.commands.registerCommand(
-            VS_CODE_COMMANDS.PROJECT_EXPLORER_OPEN_GRAPHICAL_FOCUSED,
-            async (args: OpenGraphicalFocusedArgs) => {
-                if (!args?.fileUri) {
-                    return;
-                }
-
-                await vscode.commands.executeCommand(VS_CODE_COMMANDS.SHOW_GRAPHICAL_VIEW, {
-                    fileUri: args.fileUri,
-                    focusTarget: args.focusTarget,
-                });
-            },
-        ),
-
-        vscode.commands.registerCommand(
-            VS_CODE_COMMANDS.PROJECT_EXPLORER_REVEAL_FILE,
-            async (item: { info?: string }) => {
-                if (!item.info) {
-                    return;
-                }
-                const fileUri = vscode.Uri.file(item.info);
-                const editor = await vscode.window.showTextDocument(fileUri, { preview: false });
-                await vscode.commands.executeCommand("revealInExplorer", editor.document.uri);
-            },
-        ),
-    );
-
-    // File watchers for .siddhi files
-    const fileWatcher = vscode.workspace.createFileSystemWatcher("**/*.siddhi");
-
-    context.subscriptions.push(
-        fileWatcher,
-        fileWatcher.onDidCreate(() => scheduleRefresh()),
-        fileWatcher.onDidDelete(() => scheduleRefresh()),
-        fileWatcher.onDidChange(() => scheduleRefresh()),
-    );
-
-    // Refresh on document save
-    context.subscriptions.push(
-        vscode.workspace.onDidSaveTextDocument((document) => {
-            if (document.languageId === "siddhi") {
-                scheduleRefresh();
-            }
-        }),
-    );
-
-    // Auto-refresh when tree view becomes visible
-    context.subscriptions.push(
-        treeView.onDidChangeVisibility((e) => {
-            if (e.visible) {
-                scheduleRefresh();
-            }
-        }),
-    );
-
-    // Reveal tree item when active editor changes to a .siddhi file
-    context.subscriptions.push(
-        vscode.window.onDidChangeActiveTextEditor((editor) => {
-            if (editor && editor.document.languageId === "siddhi") {
-                projectExplorerProvider?.revealInTreeView(editor.document.uri.fsPath);
-            }
-        }),
-    );
-
-    // Refresh when language server becomes ready
-    stateService.onTransition((state) => {
-        if (state.matches("ready")) {
-            scheduleRefresh();
-        }
-    });
-
-    context.subscriptions.push(treeView, {
-        dispose: () => {
+        const scheduleRefresh = () => {
             if (refreshTimeout) {
                 clearTimeout(refreshTimeout);
             }
-        },
-    });
+            refreshTimeout = setTimeout(() => {
+                projectExplorerProvider?.refresh();
+            }, 200);
+        };
+
+        void vscode.commands.executeCommand("setContext", "SI.project.empty", true);
+        void vscode.commands.executeCommand("setContext", "SI.project.loading", false);
+        void vscode.commands.executeCommand("setContext", "SI.project.error", false);
+        void vscode.commands.executeCommand("setContext", "SI.project.hasContent", false);
+        void vscode.commands.executeCommand("setContext", "SI.project.hasSiddhiFiles", false);
+
+        const treeView = vscode.window.createTreeView(PROJECT_EXPLORER_VIEW_ID, {
+            treeDataProvider: projectExplorerProvider,
+            showCollapseAll: true,
+        });
+        projectExplorerProvider.setTreeView(treeView);
+
+        // Register commands
+        context.subscriptions.push(
+            vscode.commands.registerCommand(VS_CODE_COMMANDS.PROJECT_EXPLORER_REFRESH, () => {
+                projectExplorerProvider?.refresh();
+            }),
+
+            vscode.commands.registerCommand(
+                VS_CODE_COMMANDS.PROJECT_EXPLORER_OPEN_FILE,
+                (fileUri: vscode.Uri) => {
+                    vscode.window.showTextDocument(fileUri, { preview: false });
+                },
+            ),
+
+            vscode.commands.registerCommand(
+                VS_CODE_COMMANDS.PROJECT_EXPLORER_OPEN_GRAPHICAL_FOCUSED,
+                async (args: OpenGraphicalFocusedArgs) => {
+                    if (!args?.fileUri) {
+                        return;
+                    }
+
+                    await vscode.commands.executeCommand(VS_CODE_COMMANDS.SHOW_GRAPHICAL_VIEW, {
+                        fileUri: args.fileUri,
+                        focusTarget: args.focusTarget,
+                    });
+                },
+            ),
+
+            vscode.commands.registerCommand(
+                VS_CODE_COMMANDS.PROJECT_EXPLORER_REVEAL_FILE,
+                async (item: { info?: string }) => {
+                    if (!item.info) {
+                        return;
+                    }
+                    const fileUri = vscode.Uri.file(item.info);
+                    const editor = await vscode.window.showTextDocument(fileUri, { preview: false });
+                    await vscode.commands.executeCommand("revealInExplorer", editor.document.uri);
+                },
+            ),
+        );
+
+        // File watchers for .siddhi files
+        const fileWatcher = vscode.workspace.createFileSystemWatcher("**/*.siddhi");
+
+        context.subscriptions.push(
+            fileWatcher,
+            fileWatcher.onDidCreate(() => scheduleRefresh()),
+            fileWatcher.onDidDelete(() => scheduleRefresh()),
+            fileWatcher.onDidChange(() => scheduleRefresh()),
+        );
+
+        // Refresh on document save
+        context.subscriptions.push(
+            vscode.workspace.onDidSaveTextDocument((document) => {
+                if (document.languageId === "siddhi") {
+                    scheduleRefresh();
+                }
+            }),
+        );
+
+        // Auto-refresh when tree view becomes visible
+        context.subscriptions.push(
+            treeView.onDidChangeVisibility((e) => {
+                if (e.visible) {
+                    scheduleRefresh();
+                }
+            }),
+        );
+
+        // Reveal tree item when active editor changes to a .siddhi file
+        context.subscriptions.push(
+            vscode.window.onDidChangeActiveTextEditor((editor) => {
+                scheduleRefresh();
+                if (editor && editor.document.languageId === "siddhi") {
+                    projectExplorerProvider?.revealInTreeView(editor.document.uri.fsPath);
+                }
+            }),
+        );
+
+        // Refresh when language server becomes ready
+        stateService.onTransition((state) => {
+            if (state.matches("ready")) {
+                scheduleRefresh();
+            }
+        });
+
+        context.subscriptions.push(treeView, {
+            dispose: () => {
+                if (refreshTimeout) {
+                    clearTimeout(refreshTimeout);
+                }
+            },
+        });
+    };
+
+    void initializeProjectExplorer();
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeWorkspaceFolders(() => {
+            void initializeProjectExplorer();
+        }),
+        vscode.workspace.onDidCreateFiles((event) => {
+            if (event.files.some((file) => file.path.endsWith(".siddhi"))) {
+                void initializeProjectExplorer();
+            }
+        }),
+    );
 }

--- a/workspaces/si/si-extension/src/project-explorer/project-explorer-provider.ts
+++ b/workspaces/si/si-extension/src/project-explorer/project-explorer-provider.ts
@@ -26,6 +26,8 @@ const PROJECT_CONTEXT_KEYS = {
     EMPTY: "SI.project.empty",
     LOADING: "SI.project.loading",
     ERROR: "SI.project.error",
+    HAS_CONTENT: "SI.project.hasContent",
+    HAS_SIDDHI_FILES: "SI.project.hasSiddhiFiles",
 };
 
 // Category display configuration
@@ -97,6 +99,7 @@ export class ProjectExplorerEntryProvider implements vscode.TreeDataProvider<Pro
     private _isRefreshing = false;
     private _pendingRefresh = false;
     private _lastLoadHadErrors = false;
+    private _hasSiddhiFiles = false;
 
     getTreeItem(element: ProjectExplorerEntry): vscode.TreeItem {
         return element;
@@ -186,8 +189,20 @@ export class ProjectExplorerEntryProvider implements vscode.TreeDataProvider<Pro
     }
 
     private async loadProjectStructure(): Promise<void> {
-        const langClient = StateMachine.context().langClient;
         this._lastLoadHadErrors = false;
+        const workspaceSiddhiFiles = await vscode.workspace.findFiles("**/*.siddhi");
+        const activeSiddhiFile = this.getActiveSiddhiFile();
+        const siddhiFiles = workspaceSiddhiFiles.length === 0 && activeSiddhiFile
+            ? [activeSiddhiFile]
+            : workspaceSiddhiFiles;
+        this._hasSiddhiFiles = siddhiFiles.length > 0;
+
+        if (!this._hasSiddhiFiles) {
+            this._data = [];
+            return;
+        }
+
+        const langClient = StateMachine.context().langClient;
 
         if (!langClient) {
             this._data = [
@@ -198,12 +213,6 @@ export class ProjectExplorerEntryProvider implements vscode.TreeDataProvider<Pro
                     "statusNode",
                 ),
             ];
-            return;
-        }
-
-        const siddhiFiles = await vscode.workspace.findFiles("**/*.siddhi");
-        if (siddhiFiles.length === 0) {
-            this._data = [];
             return;
         }
 
@@ -243,6 +252,19 @@ export class ProjectExplorerEntryProvider implements vscode.TreeDataProvider<Pro
         }
 
         this._data = entries;
+    }
+
+    private getActiveSiddhiFile(): vscode.Uri | undefined {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (!activeEditor || activeEditor.document.languageId !== "siddhi") {
+            return undefined;
+        }
+
+        if (activeEditor.document.uri.scheme !== "file") {
+            return undefined;
+        }
+
+        return activeEditor.document.uri;
     }
 
     private createAppEntry(
@@ -579,8 +601,11 @@ export class ProjectExplorerEntryProvider implements vscode.TreeDataProvider<Pro
     private async updateProjectContexts(): Promise<void> {
         const isLoadingOnly = this._data.some((node) => node.contextValue === "statusNode");
         const isEmpty = !isLoadingOnly && this._data.length === 0;
+        const hasContent = !isLoadingOnly && this._data.length > 0;
         await this.setProjectContext(PROJECT_CONTEXT_KEYS.EMPTY, isEmpty);
         await this.setProjectContext(PROJECT_CONTEXT_KEYS.ERROR, this._lastLoadHadErrors);
+        await this.setProjectContext(PROJECT_CONTEXT_KEYS.HAS_CONTENT, hasContent);
+        await this.setProjectContext(PROJECT_CONTEXT_KEYS.HAS_SIDDHI_FILES, this._hasSiddhiFiles);
     }
 
     private async setProjectContext(key: string, value: boolean): Promise<void> {


### PR DESCRIPTION
## Purpose
> SI Project Explorer visibility and initialization behaved inconsistently in no-project and single .siddhi file scenarios.

- When no project was open, the explorer could still try to initialize, causing UI glitches

## Goals
> Prevent unintended SI Project Explorer initialization in no-project contexts.

## Approach
> Updated the conditions that decide when SI Project Explorer is shown and used clear state flags to track whether Siddhi files are available


