### PR TITLE
fix: remove shell:true, fix log4j2 URI encoding, and show run button in graphical view

### DIFF
--- a/workspaces/si/si-extension/package.json
+++ b/workspaces/si/si-extension/package.json
@@ -230,7 +230,7 @@
         {
           "command": "SI.build-and-run",
           "group": "navigation@1",
-          "when": "resourceLangId == siddhi && SI.isRunning !== 'true'",
+          "when": "(resourceLangId == siddhi || SI.isVisualizerActive === 'true') && SI.isRunning !== 'true'",
           "title": "Build and Run Project"
         }
       ],

--- a/workspaces/si/si-extension/src/debugger/activate.ts
+++ b/workspaces/si/si-extension/src/debugger/activate.ts
@@ -46,8 +46,13 @@ export async function activateDebugger(context: vscode.ExtensionContext) {
                 return;
             }
             const editor = vscode.window.activeTextEditor;
-            const fileName = getSiddhiFileNameWithoutExtension(editor?.document.uri.fsPath!);
-            extension.fileUri = editor?.document.uri!;
+            const activeFileUri = editor?.document.uri ?? extension.fileUri;
+            if (!activeFileUri) {
+                vscode.window.showErrorMessage("No Siddhi file is open");
+                return;
+            }
+            const fileName = getSiddhiFileNameWithoutExtension(activeFileUri.fsPath);
+            extension.fileUri = activeFileUri;
 
             const launchJsonPath = path.join(workspaceFolder.uri.fsPath, ".vscode", "launch.json");
             let config: vscode.DebugConfiguration | undefined = undefined;
@@ -68,13 +73,13 @@ export async function activateDebugger(context: vscode.ExtensionContext) {
                     request: "launch",
                     noDebug: true,
                     internalConsoleOptions: "neverOpen",
-                    program: "${file}",
+                    program: activeFileUri.fsPath,
                 };
             } else {
                 config.name = `${fileName}`;
                 config.noDebug = true;
                 config.internalConsoleOptions = "neverOpen";
-                config.program = "${file}";
+                config.program = activeFileUri.fsPath;
             }
 
             try {

--- a/workspaces/si/si-extension/src/debugger/debugHelper.ts
+++ b/workspaces/si/si-extension/src/debugger/debugHelper.ts
@@ -41,19 +41,13 @@ export async function startSiddhiApp(siddhiHome: string, javaHome: string, progr
     args.push(SIDDHI_APP_RUNNER, program);
 
     let executable: string = path.join(String(javaHome), "bin", "java");
-    
-    if (process.platform === "win32") {
-        if (!executable.endsWith(".exe")) {
-            executable += ".exe";
-        }
-        if (executable.includes(" ")) {
-            executable = `"${executable}"`;
-        }
+
+    if (process.platform === "win32" && !executable.endsWith(".exe")) {
+        executable += ".exe";
     }
-    
+
     let javaProcess = child_process.spawn(executable, args, {
         stdio: ["pipe", "pipe", "pipe"],
-        shell: true,
         env: {
             ...process.env,
             CARBON_HOME: siddhiHome,

--- a/workspaces/si/si-extension/src/server/server.ts
+++ b/workspaces/si/si-extension/src/server/server.ts
@@ -91,7 +91,6 @@ export function installJars(carbonHome: string) {
     // Spawn the Java process
     const javaProcess = child_process.spawn(javaExecutable, args, {
         stdio: ["pipe", "pipe", "pipe"],
-        shell: true,
         env: {
             ...process.env,
             CARBON_HOME: carbonHome,

--- a/workspaces/si/si-extension/src/utils/utils.ts
+++ b/workspaces/si/si-extension/src/utils/utils.ts
@@ -11,6 +11,7 @@ import * as vscode from "vscode";
 import { StreamAttributesResponse, StreamResponse } from "@wso2/si-core";
 import * as path from "path";
 import * as fs from "fs";
+import { pathToFileURL } from "url";
 import { extension } from "../SIExtensionContext";
 
 type Result = {
@@ -202,12 +203,8 @@ export function getSiddhiFileNameWithoutExtension(filePath: string): string {
 
 
 export function getLog4jConfigFile(platform: string, jarPath: string): string {
-    if (platform === 'win32') {
-        const normalizedPath = jarPath.replace(/\\/g, '/');
-        return 'jar:file:///' + normalizedPath + '!/log4j2.properties';
-    } else {
-        return 'jar:file:' + jarPath + '!/log4j2.properties';
-    }
+    const fileUrl = pathToFileURL(jarPath).toString();
+    return 'jar:' + fileUrl + '!/log4j2.properties';
 }
 
 export function findLSJarPath(jar: string): string {


### PR DESCRIPTION
## Summary

Fixes https://github.com/wso2/product-integrator/issues/1187
Fixes https://github.com/wso2/product-integrator/issues/1185

### Fix 1: ClassNotFoundException / wrong main class
`shell: true` in `child_process.spawn()` joins the executable and all args into a single unquoted shell string. When any path component contains a space (e.g. `WSO2 Integrator.app`), the shell splits the classpath argument there — the second half is passed to Java as the main class instead of the actual main class name. Removing `shell: true` lets Node.js pass each arg directly to `execvp`, unaffected by spaces. The `*` wildcard in the classpath is a JVM feature (since Java 6) and does not require shell expansion. The Windows-specific path-quoting workaround (wrapping the executable in `\"...\"`) is also removed as it was only needed in shell mode.

### Fix 2: StatusLogger Reconfiguration failed
`getLog4jConfigFile` constructed `jar:file:` URIs by plain string concatenation, leaving spaces in the path unencoded. Replaced with `pathToFileURL` which percent-encodes spaces and other special characters, producing a valid URI on both macOS and Windows.

### Fix 3: Run button missing and non-functional in graphical view
The run button disappeared when switching to the graphical/design view (a VS Code webview panel) because the `editor/title/run` when clause required `resourceLangId == siddhi`, which is undefined for webview panels. Additionally, the `BUILD_AND_RUN` command used `vscode.window.activeTextEditor` (which is `undefined` in webview context) and the `${file}` debug config variable (which VS Code cannot resolve without an active text editor).

## Files changed

| File | Change |
|---|---|
| `src/debugger/debugHelper.ts` | Remove `shell: true` and unnecessary Windows path-quoting from `startSiddhiApp` |
| `src/server/server.ts` | Remove `shell: true` from `installJars` |
| `src/utils/utils.ts` | Use `pathToFileURL` in `getLog4jConfigFile` for correct URI encoding |
| `package.json` | Update `editor/title/run` when clause to also show run button when `SI.isVisualizerActive === 'true'` |
| `src/debugger/activate.ts` | Fall back to `extension.fileUri` when no active text editor; replace `"${file}"` with resolved `activeFileUri.fsPath` |

## Test plan

- [ ] Click the Run button on a `.siddhi` file inside the WSO2 Integrator app — Java process should start without `ClassNotFoundException`
- [ ] Confirm no `StatusLogger Reconfiguration failed` error in the Output console on startup
- [ ] Verify the above on a path containing spaces (e.g. installed under `WSO2 Integrator.app`)
- [ ] Switch to the graphical view — run button should remain visible in the toolbar
- [ ] Click run from the graphical view — app should start without "Variable \${file} can not be resolved" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)