### PR TITLE
fix: fall back to extension.fileUri when rerun omits program path

### DIFF
--- a/workspaces/si/si-extension/src/debugger/debugAdapter.ts
+++ b/workspaces/si/si-extension/src/debugger/debugAdapter.ts
@@ -16,6 +16,7 @@ import { VS_CODE_COMMANDS } from "../constants";
 import { DebuggerConfig } from "./config";
 import { Subject } from "await-notify";
 import { debug } from "../utils/logger";
+import { extension } from "../SIExtensionContext";
 
 interface ILaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
     env?: any;
@@ -73,7 +74,15 @@ export class SiDebugAdapter extends LoggingDebugSession {
                         DebuggerConfig.setVmArgs(args?.vmArgs ? args?.vmArgs : []);
                         vscode.commands.executeCommand("setContext", "SI.isRunning", "true");
 
-                        startSiddhiApp(serverPath, javaHome!, args!.program!)
+                        const program = args?.program ?? extension.fileUri?.fsPath;
+                        if (!program) {
+                            const message = `No Siddhi file found to run`;
+                            vscode.window.showErrorMessage(message);
+                            this.sendError(response, 1, message);
+                            return;
+                        }
+
+                        startSiddhiApp(serverPath, javaHome!, program)
                             .then(async () => {
                                 this.sendResponse(response);
                             })


### PR DESCRIPTION
## Summary

- When the VS Code debug toolbar **rerun** button is clicked, a new debug session is created without the original launch arguments, so `args.program` arrives as `undefined` in `launchRequest`
- This caused `path.basename(undefined, ".siddhi")` to throw `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined`
- Run and stop buttons were unaffected; only rerun was broken

## Fix

In `debugAdapter.ts`, resolve the program path with a fallback to `extension.fileUri?.fsPath` — the global extension context that is already populated on every initial run (`activate.ts` line 55). Added a guard for the unlikely case where both are undefined.

## Test plan

- [ ] Open a `.siddhi` file and click **Run** — confirm it starts normally
- [ ] Click **Rerun** — confirm it stops and restarts without the `ERR_INVALID_ARG_TYPE` error
- [ ] Click **Stop** — confirm it stops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)