### PR TITLE
Make modal dialogs responsive to viewport width

### DIFF
--- a/workspaces/si/si-extension/src/web/editor/commons/css/fileDialog.css
+++ b/workspaces/si/si-extension/src/web/editor/commons/css/fileDialog.css
@@ -93,7 +93,8 @@ hr.style1 {
 }
 
 .file-dialog {
-    width: 745px;
+    width: 90%;
+    max-width: 745px;
 }
 
 .file-dialog-title{


### PR DESCRIPTION
## Purpose
> resolves issue: https://github.com/wso2/product-integrator/issues/1358

## Approach
>This pull request makes a minor adjustment to the styling of the `.file-dialog` class in `fileDialog.css` to improve its responsiveness.

- UI improvement:
  * Changed the `.file-dialog` width to `90%` and set a `max-width` of `745px` to make the dialog more responsive on different screen sizes.
  
https://github.com/user-attachments/assets/732f5786-e0e4-429b-8295-8c805bd69539


