### PR TITLE
Improve Java home config fallback and reorder setup UI

### DIFF
--- a/workspaces/si/si-extension/src/utils/onboardingUtils.ts
+++ b/workspaces/si/si-extension/src/utils/onboardingUtils.ts
@@ -284,9 +284,12 @@ export function getJavaHomeFromConfig(): string | undefined {
     let javaHome = vscode.workspace.getConfiguration().get("siddhi.javaHome") as string;
     if (javaHome) {
         return javaHome;
-    } else {
-        return process.env.JAVA_HOME;
+    } 
+    const envJavaHome = process.env.JAVA_HOME;
+    if (envJavaHome && verifyJavaHomePath(envJavaHome)) {
+        return envJavaHome;
     }
+    return undefined;
 }
 
 function getCurrentUpdateVersion(siPath: string): string {

--- a/workspaces/si/si-visualizer/src/views/EnvironmentSetup/index.tsx
+++ b/workspaces/si/si-visualizer/src/views/EnvironmentSetup/index.tsx
@@ -340,7 +340,6 @@ export const EnvironmentSetup = () => {
             </TitlePanel>
             <>
                 <StepContainer>
-                    {renderContinue()}
                     <hr style={{ flexGrow: 1, margin: '0 10px', borderColor: 'var(--vscode-editorIndentGuide-background)' }} />
                     {renderJava()}
                     {renderSI()}
@@ -385,6 +384,7 @@ export const EnvironmentSetup = () => {
                                 )}
                             </React.Fragment>
                         </FormGroup>}
+                    {renderContinue()}
                 </StepContainer>
             </>
             {error && <ErrorMessage>{error}</ErrorMessage>}


### PR DESCRIPTION
resolves issue : https://github.com/wso2/product-integrator/issues/1324

**Improvements to Java Home detection:**
- Updated `getJavaHomeFromConfig` in `onboardingUtils.ts` to only return `JAVA_HOME` from the environment if it passes validation with `verifyJavaHomePath`, and otherwise return `undefined` instead of potentially returning an invalid path.

**User interface adjustments:**
- Moved the rendering of the "Continue" button in `EnvironmentSetup/index.tsx` to appear after the Java and SI setup steps, improving the logical flow of the setup process. [[1]](diffhunk://#diff-d7d50d749cee7c5b17519c0d6f66f646ab27c4d743b9feefd227795ac99c523cL343) [[2]](diffhunk://#diff-d7d50d749cee7c5b17519c0d6f66f646ab27c4d743b9feefd227795ac99c523cR387)
This pull request refines the logic for determining the Java Home path in the onboarding utilities and adjusts the rendering order of setup steps in the environment setup UI. The main improvements include stricter validation of the `JAVA_HOME` environment variable and a more logical placement of the "Continue" button in the setup workflow.
