### PR TITLE
Remove left port in the trigger node

### DIFF
--- a/workspaces/si/si-extension/src/web/editor/css/design-view.css
+++ b/workspaces/si/si-extension/src/web/editor/css/design-view.css
@@ -297,7 +297,7 @@ td {
     -webkit-background-clip: text;
 }
 
-.connectorInStream, .connectorInTable, .connectorInWindow, .connectorInTrigger, .connectorInAggregation,
+.connectorInStream, .connectorInTable, .connectorInWindow, .connectorInAggregation,
 .connectorInQuery, .connectorInPatternQuery, .connectorInSequenceQuery, .connectorInJoinQuery, .connectorInSink,
 .connectorInSource {
     float: left;

--- a/workspaces/si/si-extension/src/web/editor/js/design-view/drop-elements.js
+++ b/workspaces/si/si-extension/src/web/editor/js/design-view/drop-elements.js
@@ -666,11 +666,8 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
             /*
              connection --> The connection anchor point is appended to the element
              */
-            var connection1 = $('<div class="connectorInTrigger">').attr('id', i + "-in").addClass('connection');
             var connection2 = $('<div class="connectorOutTrigger">').attr('id', i + "-out").addClass('connection');
 
-
-            finalElement.append(connection1);
             finalElement.append(connection2);
 
             finalElement.css({
@@ -686,11 +683,6 @@ define(['require', 'log', 'lodash', 'jquery', 'partition', 'stream', 'query', 'f
                     finalElement.attr('data-x', e.e.clientX);
                     finalElement.attr('data-y', e.e.clientY);
                 }
-            });
-
-            self.jsPlumbInstance.makeTarget(connection1, {
-                deleteEndpointsOnDetach: true,
-                anchor: 'Left'
             });
 
             self.jsPlumbInstance.makeSource(connection2, {


### PR DESCRIPTION

## Purpose
> remove input port in the trigger node as it always acts as a source.
resolves issue: https://github.com/wso2/product-integrator/issues/1392

## Approach
* Removed the `.connectorInTrigger` class from the selector list in `design-view.css`, so input connectors for triggers are no longer styled or displayed.
* Removed the creation and appending of the input connector (`connection1` with class `connectorInTrigger`) for triggers in `drop-elements.js`.

<img width="2638" height="1250" alt="image" src="https://github.com/user-attachments/assets/ee4e38eb-3d32-4dac-845c-e0a26afc52dc" />


